### PR TITLE
Using Get-CVClient command instead of Get-CVId

### DIFF
--- a/Modules/Commvault.JobManager/Commvault.JobManager.psm1
+++ b/Modules/Commvault.JobManager/Commvault.JobManager.psm1
@@ -172,7 +172,7 @@ function Get-CVJob {
             }
             else {
                 if (-not [String]::IsNullOrEmpty($ClientName)) {
-                    $clientObj = Get-CVId -ClientName $ClientName
+                    $clientObj = Get-CVClient -Client $ClientName
                     if ($null -ne $clientObj) { 
                         $sessionObj.requestProps.endpoint += '&clientId=' + $clientObj.clientId
                     }


### PR DESCRIPTION
Using Get-CVClient command instead of Get-CVId as Get-CVId doesn't yet return null object if ClientName passed is not found.