### PR TITLE
Enhance Get-CVSubclient for faster execution

### DIFF
--- a/Modules/Commvault.RESTSession/Commvault.RESTSession.psm1
+++ b/Modules/Commvault.RESTSession/Commvault.RESTSession.psm1
@@ -793,7 +793,7 @@ function GetAPIDetail ([String] $Request) {
             'Get-CVSubclient' = @{
         
                 Description = 'Get subclient list for given clientId from CommServe'
-                Endpoint    = 'Subclient?clientId={clientId}&propertyLevel=AllProperties'
+                Endpoint    = 'Subclient?clientId={clientId}'
                 Method      = 'Get'
                 Body        = ''
             


### PR DESCRIPTION
Removing the AllProperties param in the cmdlet to have faster execution of Get-CVSubclient .