### PR TITLE
Fix Restore-CVSqlDatabase where multiple DBs have similar names

### DIFF
--- a/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
+++ b/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
@@ -1604,7 +1604,7 @@ function Restore-CVSQLDatabase {
                     return
                 }
     
-                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName | Where-Object { $_.insName -ieq $name }
+                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName | Where-Object { $_.insName -ieq $PSBoundParameters.DestClientName }
                 if ($null -eq $instanceObj) { 
                     Write-Information -InformationAction Continue -MessageData "INFO: $($MyInvocation.MyCommand): destination instance not found having name [$($PSBoundParameters.DestInstanceName)]"      
                     return

--- a/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
+++ b/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
@@ -1604,7 +1604,7 @@ function Restore-CVSQLDatabase {
                     return
                 }
     
-                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName | Where-Object { $_.insName -ieq $PSBoundParameters.DestClientName }
+                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName | Where-Object { $_.insName -ieq $PSBoundParameters.DestInstanceName }
                 if ($null -eq $instanceObj) { 
                     Write-Information -InformationAction Continue -MessageData "INFO: $($MyInvocation.MyCommand): destination instance not found having name [$($PSBoundParameters.DestInstanceName)]"      
                     return

--- a/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
+++ b/Modules/Commvault.SQLServer/Commvault.SQLServer.psm1
@@ -1604,7 +1604,7 @@ function Restore-CVSQLDatabase {
                     return
                 }
     
-                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName
+                $instanceObj = Get-CVSQLInstance -Name $PSBoundParameters.DestInstanceName | Where-Object { $_.insName -ieq $name }
                 if ($null -eq $instanceObj) { 
                     Write-Information -InformationAction Continue -MessageData "INFO: $($MyInvocation.MyCommand): destination instance not found having name [$($PSBoundParameters.DestInstanceName)]"      
                     return


### PR DESCRIPTION
Due to similar names, Get-CVSqlInstance is returning the list of all matching db with the prefix.. 
We need to filter it out again based on the input dest client and form the body correctly